### PR TITLE
add mul device type use  nvidia.com/gpu-h100 like requests/limits

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/go
+{
+	"name": "Go",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/go:1-1.22-bookworm"
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "go version",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/charts/hami/templates/device-plugin/configmap.yaml
+++ b/charts/hami/templates/device-plugin/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.devicePlugin.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -17,3 +18,4 @@ data:
             }
         ]
     }
+{{- end }}

--- a/charts/hami/templates/device-plugin/daemonsetnvidia.yaml
+++ b/charts/hami/templates/device-plugin/daemonsetnvidia.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.devicePlugin.enabled }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -143,3 +144,4 @@ spec:
       {{- if .Values.devicePlugin.tolerations }}
       tolerations: {{ toYaml .Values.devicePlugin.tolerations | nindent 8 }}
       {{- end }}
+{{- end }}

--- a/charts/hami/templates/device-plugin/monitorrole.yaml
+++ b/charts/hami/templates/device-plugin/monitorrole.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.devicePlugin.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -23,5 +24,6 @@ rules:
       - update
       - list
       - patch
-    
+{{- end }}
+   
     

--- a/charts/hami/templates/device-plugin/monitorrolebinding.yaml
+++ b/charts/hami/templates/device-plugin/monitorrolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.devicePlugin.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -14,3 +15,4 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "hami-vgpu.device-plugin" . }}
     namespace: {{ .Release.Namespace | quote }}
+{{- end }}

--- a/charts/hami/templates/device-plugin/monitorservice.yaml
+++ b/charts/hami/templates/device-plugin/monitorservice.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.devicePlugin.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -21,3 +22,4 @@ spec:
       port: {{ .Values.devicePlugin.service.httpPort }}
       targetPort: 9394
       nodePort: {{ .Values.devicePlugin.service.httpPort }}
+{{- end }}

--- a/charts/hami/templates/device-plugin/monitorserviceaccount.yaml
+++ b/charts/hami/templates/device-plugin/monitorserviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.devicePlugin.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -6,3 +7,5 @@ metadata:
   labels:
     app.kubernetes.io/component: "hami-device-plugin"
     {{- include "hami-vgpu.labels" . | nindent 4 }}
+
+{{- end }}

--- a/charts/hami/templates/scheduler/configmap.yaml
+++ b/charts/hami/templates/scheduler/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.scheduler.enabled }}
 {{- if .Values.scheduler.kubeScheduler.enabled }}
 apiVersion: v1
 kind: ConfigMap
@@ -77,4 +78,5 @@ data:
             }
         ]
     }
+{{- end }}
 {{- end }}

--- a/charts/hami/templates/scheduler/configmap.yaml
+++ b/charts/hami/templates/scheduler/configmap.yaml
@@ -25,10 +25,12 @@ data:
                     "insecure": true
                 },
                 "managedResources": [
+                    {{- range ( split ";" $.Values.resourceName ) }}
                     {
-                        "name": "{{ .Values.resourceName }}",
+                        "name": "{{ . }}",
                         "ignoredByScheduler": true
                     },
+                    {{- end }}
                     {
                         "name": "{{ .Values.resourceMem }}",
                         "ignoredByScheduler": true

--- a/charts/hami/templates/scheduler/configmapnew.yaml
+++ b/charts/hami/templates/scheduler/configmapnew.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.scheduler.enabled }}
 {{- if .Values.scheduler.kubeScheduler.enabled }}
 apiVersion: v1
 kind: ConfigMap
@@ -53,4 +54,5 @@ data:
         ignoredByScheduler: true
       - name: {{ .Values.ascendResourceName }}
         ignoredByScheduler: true
+{{- end }}
 {{- end }}

--- a/charts/hami/templates/scheduler/configmapnew.yaml
+++ b/charts/hami/templates/scheduler/configmapnew.yaml
@@ -30,8 +30,10 @@ data:
       tlsConfig:
         insecure: true
       managedResources:
-      - name: {{ .Values.resourceName }}
+      {{- range ( split ";" $.Values.resourceName ) }}
+      - name: {{ . }}
         ignoredByScheduler: true
+      {{- end }}
       - name: {{ .Values.resourceMem }}
         ignoredByScheduler: true
       - name: {{ .Values.resourceCores }}

--- a/charts/hami/templates/scheduler/deployment.yaml
+++ b/charts/hami/templates/scheduler/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.scheduler.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -114,3 +115,4 @@ spec:
       {{- if .Values.scheduler.nodeName }}
       nodeName: {{ .Values.scheduler.nodeName }}
       {{- end }}
+{{- end }}

--- a/charts/hami/templates/scheduler/job-patch/clusterrole.yaml
+++ b/charts/hami/templates/scheduler/job-patch/clusterrole.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.scheduler.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -23,4 +24,5 @@ rules:
     verbs:     ['use']
     resourceNames:
     - {{ include "hami-vgpu.fullname" . }}-admission
+{{- end }}
 {{- end }}

--- a/charts/hami/templates/scheduler/job-patch/clusterrolebinding.yaml
+++ b/charts/hami/templates/scheduler/job-patch/clusterrolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.scheduler.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -16,3 +17,4 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "hami-vgpu.fullname" . }}-admission
     namespace: {{ .Release.Namespace | quote }}
+{{- end }}

--- a/charts/hami/templates/scheduler/job-patch/job-createSecret.yaml
+++ b/charts/hami/templates/scheduler/job-patch/job-createSecret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.scheduler.enabled }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -58,3 +59,4 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: {{ .Values.scheduler.patch.runAsUser }}
+{{- end }}

--- a/charts/hami/templates/scheduler/job-patch/job-patchWebhook.yaml
+++ b/charts/hami/templates/scheduler/job-patch/job-patchWebhook.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.scheduler.enabled }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -53,3 +54,4 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: {{ .Values.scheduler.patch.runAsUser }}
+{{- end }}

--- a/charts/hami/templates/scheduler/job-patch/psp.yaml
+++ b/charts/hami/templates/scheduler/job-patch/psp.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.scheduler.enabled }}
 {{- if .Values.podSecurityPolicy.enabled }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
@@ -33,4 +34,5 @@ spec:
   - projected
   - secret
   - downwardAPI
+{{- end }}
 {{- end }}

--- a/charts/hami/templates/scheduler/job-patch/role.yaml
+++ b/charts/hami/templates/scheduler/job-patch/role.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.scheduler.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -16,3 +17,4 @@ rules:
     verbs:
       - get
       - create
+{{- end }}

--- a/charts/hami/templates/scheduler/job-patch/rolebinding.yaml
+++ b/charts/hami/templates/scheduler/job-patch/rolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.scheduler.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -16,3 +17,4 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "hami-vgpu.fullname" . }}-admission
     namespace: {{ .Release.Namespace | quote }}
+{{- end }}

--- a/charts/hami/templates/scheduler/job-patch/serviceaccount.yaml
+++ b/charts/hami/templates/scheduler/job-patch/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.scheduler.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -8,3 +9,4 @@ metadata:
   labels:
     {{- include "hami-vgpu.labels" . | nindent 4 }}
     app.kubernetes.io/component: admission-webhook
+{{- end }}

--- a/charts/hami/templates/scheduler/rolebinding.yaml
+++ b/charts/hami/templates/scheduler/rolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.scheduler.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -13,3 +14,4 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "hami-vgpu.scheduler" . }}
     namespace: {{ .Release.Namespace | quote }}
+{{- end }}

--- a/charts/hami/templates/scheduler/service.yaml
+++ b/charts/hami/templates/scheduler/service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.scheduler.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -27,4 +28,4 @@ spec:
   selector:
     app.kubernetes.io/component: hami-scheduler
     {{- include "hami-vgpu.selectorLabels" . | nindent 4 }}
-
+{{- end }}

--- a/charts/hami/templates/scheduler/serviceaccount.yaml
+++ b/charts/hami/templates/scheduler/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.scheduler.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -6,3 +7,4 @@ metadata:
   labels:
     app.kubernetes.io/component: "hami-scheduler"
     {{- include "hami-vgpu.labels" . | nindent 4 }}
+{{- end }}

--- a/charts/hami/templates/scheduler/webhook.yaml
+++ b/charts/hami/templates/scheduler/webhook.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.scheduler.enabled }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
@@ -43,3 +44,4 @@ webhooks:
         scope: '*'
     sideEffects: None
     timeoutSeconds: 10
+{{- end }}

--- a/charts/hami/values.yaml
+++ b/charts/hami/values.yaml
@@ -42,6 +42,7 @@ global:
   annotations: {}
 
 scheduler:
+  enabled: true
   # @param nodeName defines the node name and the nvidia-vgpu-scheduler-scheduler will schedule to the node.
   # if we install the nvidia-vgpu-scheduler-scheduler as default scheduler, we need to remove the k8s defualt
   # scheduler pod from the cluster first, we must specified node name to skip the schedule workflow.
@@ -104,6 +105,7 @@ scheduler:
     annotations: {}
 
 devicePlugin:
+  enabled: true
   image: "projecthami/hami"
   monitorimage: "projecthami/hami"
   monitorctrPath: /usr/local/vgpu/containers

--- a/charts/hami/values.yaml
+++ b/charts/hami/values.yaml
@@ -6,7 +6,9 @@ imagePullSecrets: [ ]
 version: "v2.3.12"
 
 #Nvidia GPU Parameters
-resourceName: "nvidia.com/gpu"
+# resourceName: "nvidia.com/gpu-h100;nvidia.com/gpu-h20"
+# resourceName: "nvidia.com/gpu-h20"
+resourceName: "nvidia.com/gpu-h100"
 resourceMem: "nvidia.com/gpumem"
 resourceMemPercentage: "nvidia.com/gpumem-percentage"
 resourceCores: "nvidia.com/gpucores"
@@ -77,6 +79,7 @@ scheduler:
   podAnnotations: {}
   #nodeSelector: 
   #  gpu: "on"
+  #  nvidia-device: "h20"
   tolerations: []
   #serviceAccountName: "hami-vgpu-scheduler-sa"
   customWebhook:
@@ -118,6 +121,7 @@ devicePlugin:
   disablecorelimit: "false"
   extraArgs:
     - -v=false
+    # - --custom-device-type=NVIDIA H20 96GB HBM3
   
   service:
     httpPort: 31992
@@ -128,5 +132,6 @@ devicePlugin:
   podAnnotations: {}
   nvidianodeSelector:
     gpu: "on"
+    # nvidia-device: "h20"
   tolerations: []
 

--- a/cmd/device-plugin/nvidia/vgpucfg.go
+++ b/cmd/device-plugin/nvidia/vgpucfg.go
@@ -66,6 +66,11 @@ func addFlags() []cli.Flag {
 			Value: "nvidia.com/gpu",
 			Usage: "the name of field for number GPU visible in container",
 		},
+		&cli.StringFlag{
+			Name:  "custom-device-type",
+			Value: "NVIDIA H100 80GB HBM3",
+			Usage: "the name of field for custom device type for debugger",
+		},
 	}
 	return addition
 }
@@ -146,6 +151,9 @@ func generateDeviceConfigFromNvidia(cfg *spec.Config, c *cli.Context, flags []cl
 			}
 			if strings.Compare(n, "resource-name") == 0 {
 				updateFromCLIFlag(&devcfg.ResourceName, c, n)
+			}
+			if strings.Compare(n, "custom-device-type") == 0 {
+				updateFromCLIFlag(&util.CustomModelName, c, n)
 			}
 		}
 	}

--- a/docker/rebuild.dockerfile
+++ b/docker/rebuild.dockerfile
@@ -1,0 +1,4 @@
+FROM  projecthami/hami:v2.3.12
+
+COPY scheduler /k8s-vgpu/bin
+COPY nvidia-device-plugin /k8s-vgpu/bin

--- a/pkg/device-plugin/nvidiadevice/nvinternal/plugin/register.go
+++ b/pkg/device-plugin/nvidiadevice/nvinternal/plugin/register.go
@@ -92,7 +92,7 @@ func parseNvidiaNumaInfo(idx int, nvidiaTopoStr string) (int, error) {
 	return result, nil
 }
 
-func (plugin *NvidiaDevicePlugin) getAPIDevices(customeModel string) *[]*api.DeviceInfo {
+func (plugin *NvidiaDevicePlugin) getAPIDevices(customModel string) *[]*api.DeviceInfo {
 	devs := plugin.Devices()
 	nvml.Init()
 	res := make([]*api.DeviceInfo, 0, len(devs))
@@ -147,8 +147,8 @@ func (plugin *NvidiaDevicePlugin) getAPIDevices(customeModel string) *[]*api.Dev
 			klog.ErrorS(err, "failed to get numa information", "idx", idx)
 		}
 		var deviceType string
-		if customeModel != "" {
-			deviceType = fmt.Sprintf("%v-%v", "NVIDIA", customeModel)
+		if customModel != "" {
+			deviceType = fmt.Sprintf("%v-%v", "NVIDIA", customModel)
 		} else {
 			deviceType = fmt.Sprintf("%v-%v", "NVIDIA", Model)
 		}

--- a/pkg/scheduler/score.go
+++ b/pkg/scheduler/score.go
@@ -69,7 +69,7 @@ func fitInCertainDevice(node *NodeUsage, request util.ContainerDeviceRequest, an
 	var tmpDevs map[string]util.ContainerDevices
 	tmpDevs = make(map[string]util.ContainerDevices)
 	for i := len(node.Devices.DeviceLists) - 1; i >= 0; i-- {
-		klog.InfoS("scoring pod", "pod", klog.KObj(pod), "Memreq", k.Memreq, "MemPercentagereq", k.MemPercentagereq, "Coresreq", k.Coresreq, "Nums", k.Nums, "device index", i, "device", node.Devices.DeviceLists[i].Device.ID)
+		klog.InfoS("scoring pod", "pod", klog.KObj(pod), "Memreq", k.Memreq, "MemPercentagereq", k.MemPercentagereq, "Coresreq", k.Coresreq, "Nums", k.Nums, "GpuType", k.GpuType, "Type", k.Type, "device index", i, "device", node.Devices.DeviceLists[i].Device.ID)
 		found, numa := checkType(annos, *node.Devices.DeviceLists[i].Device, k)
 		if !found {
 			klog.InfoS("card type mismatch,continuing...", "pod", klog.KObj(pod), (node.Devices.DeviceLists[i].Device).Type, k.Type)

--- a/pkg/util/types.go
+++ b/pkg/util/types.go
@@ -95,6 +95,7 @@ type ContainerDevice struct {
 type ContainerDeviceRequest struct {
 	Nums             int32
 	Type             string
+	GpuType          string
 	Memreq           int32
 	MemPercentagereq int32
 	Coresreq         int32

--- a/pkg/util/types.go
+++ b/pkg/util/types.go
@@ -74,6 +74,7 @@ var (
 	NodeName            string
 	RuntimeSocketFlag   string
 	DisableCoreLimit    *bool
+	CustomModelName     *string
 )
 
 //	type ContainerDevices struct {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -366,3 +366,16 @@ func MarkAnnotationsToDelete(devType string, nn string) error {
 	}
 	return PatchNodeAnnotations(n, tmppat)
 }
+
+// resource name format: company/device-type,like: nvidia.com/gpu-h100
+func GetGpuTypeFromResourceName(ResName string) string {
+	temp1 := strings.Split(ResName, "/")
+	if len(temp1) != 2 {
+		return ""
+	}
+	temp2 := strings.Split(temp1[1], "-")
+	if len(temp2) != 2 {
+		return ""
+	}
+	return temp2[1]
+}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -171,3 +171,10 @@ func Test_DecodePodDevices(t *testing.T) {
 		})
 	}
 }
+
+func Test_GetGpuTypeFromResourceName(t *testing.T) {
+	resName := "nvidia.com/gpu-h100"
+	gpuType := GetGpuTypeFromResourceName(resName)
+
+	assert.Equal(t, "h100", gpuType)
+}


### PR DESCRIPTION
in native hami, all nvidia device card use the same requests/limits type- "nvidia.com/gpu",
we want HAMi support "nvidia.com/gpu-h100"/"nvidia.com/gpu-h20" in the one HAMi scheduler

/kind feature

in this feature:
1\  you can use "nvidia.com/gpu-h100"/"nvidia.com/gpu-h20" in the same HAMi scheduler
2\  you can add custom device type in nvidia-plugin-device daemonset, in order to custom device type for debugger
3\  you can use quota with "requests.nvidia.com/gpu-h20" "requests.nvidia.com/gpu-h100" 

@nkwangleiGIT 

